### PR TITLE
Add z-index to notifications so they always show up.

### DIFF
--- a/src/styles/ng-notify.sass
+++ b/src/styles/ng-notify.sass
@@ -17,6 +17,7 @@
     -moz-user-select: none
     -ms-user-select: none
     user-select: none
+    z-index: 9999
 
 .ngn-top
     top: 0


### PR DESCRIPTION
Right now, notifications do not show in ionic, as there are elements at higher z-indexes.