### PR TITLE
Fix problem with ui-bootstrap modal

### DIFF
--- a/src/styles/ng-notify.sass
+++ b/src/styles/ng-notify.sass
@@ -17,6 +17,7 @@
     -moz-user-select: none
     -ms-user-select: none
     user-select: none
+    z-index: 9999
 
 .ngn-top
     top: 0


### PR DESCRIPTION
When used together with ui-bootstrap modal, ngNotify notification displayed below the modal dialog. This commit fixed the problem by adding z-index on .ngn

I assume that the CSS file are generated by the sass file, so I only add z-index to sass file, and not to the css.