### PR TITLE
Fixes blank message when service is configured in a run block

### DIFF
--- a/src/scripts/ng-notify.js
+++ b/src/scripts/ng-notify.js
@@ -136,7 +136,9 @@
 
                 // Add the template to the page...
 
-                $document.find('body').append(tpl);
+                $timeout(function() {
+                    $document.find('body').append(tpl);
+                });
 
                 // Private methods...
 

--- a/test/unit/instance.js
+++ b/test/unit/instance.js
@@ -17,9 +17,10 @@ describe('ngNotify', function() {
         module('ngNotify')
     );
 
-    beforeEach(inject(function($injector, $document) {
+    beforeEach(inject(function($injector, $document, $timeout) {
 
         ngNotify = $injector.get('ngNotify');
+        $timeout.flush();
 
         doc = $document;
 

--- a/test/unit/test.addTheme.method.js
+++ b/test/unit/test.addTheme.method.js
@@ -20,9 +20,10 @@ describe('ngNotify addTheme method', function() {
 
     beforeEach(module('ngNotify'));
 
-    beforeEach(inject(function($injector, $document) {
+    beforeEach(inject(function($injector, $document, $timeout) {
 
         ngNotify = $injector.get('ngNotify');
+        $timeout.flush();
 
         doc = $document;
 

--- a/test/unit/test.addType.method.js
+++ b/test/unit/test.addType.method.js
@@ -20,9 +20,10 @@ describe('ngNotify addType method', function() {
 
     beforeEach(module('ngNotify'));
 
-    beforeEach(inject(function($injector, $document) {
+    beforeEach(inject(function($injector, $document, $timeout) {
 
         ngNotify = $injector.get('ngNotify');
+        $timeout.flush();
 
         doc = $document;
 

--- a/test/unit/test.config.default.js
+++ b/test/unit/test.config.default.js
@@ -23,6 +23,7 @@ describe('ngNotify default configuration', function() {
     beforeEach(inject(function($injector, $document, $interval, $timeout) {
 
         ngNotify = $injector.get('ngNotify');
+        $timeout.flush();
 
         doc = $document;
         interval = $interval;

--- a/test/unit/test.config.method.object.js
+++ b/test/unit/test.config.method.object.js
@@ -23,6 +23,7 @@ describe('ngNotify config method', function() {
     beforeEach(inject(function($injector, $document, $interval, $timeout) {
 
         ngNotify = $injector.get('ngNotify');
+        $timeout.flush();
 
         doc = $document;
         interval = $interval;

--- a/test/unit/test.config.object.html.js
+++ b/test/unit/test.config.object.html.js
@@ -18,9 +18,10 @@ describe('ngNotify html configuration', function() {
 
     beforeEach(module('ngNotify'));
 
-    beforeEach(inject(function($injector, $document) {
+    beforeEach(inject(function($injector, $document, $timeout) {
 
         ngNotify = $injector.get('ngNotify');
+        $timeout.flush();
 
         doc = $document;
 

--- a/test/unit/test.config.object.position.js
+++ b/test/unit/test.config.object.position.js
@@ -18,9 +18,10 @@ describe('ngNotify position configuration', function() {
 
     beforeEach(module('ngNotify'));
 
-    beforeEach(inject(function($injector, $document) {
+    beforeEach(inject(function($injector, $document, $timeout) {
 
         ngNotify = $injector.get('ngNotify');
+        $timeout.flush();
 
         doc = $document;
 

--- a/test/unit/test.config.object.sticky.js
+++ b/test/unit/test.config.object.sticky.js
@@ -23,6 +23,7 @@ describe('ngNotify sticky configuration', function() {
     beforeEach(inject(function($injector, $document, $interval, $timeout) {
 
         ngNotify = $injector.get('ngNotify');
+        $timeout.flush();
 
         doc = $document;
         interval = $interval;

--- a/test/unit/test.config.object.theme.js
+++ b/test/unit/test.config.object.theme.js
@@ -18,9 +18,10 @@ describe('ngNotify theme configuration', function() {
 
     beforeEach(module('ngNotify'));
 
-    beforeEach(inject(function($injector, $document) {
+    beforeEach(inject(function($injector, $document, $timeout) {
 
         ngNotify = $injector.get('ngNotify');
+        $timeout.flush();
 
         doc = $document;
 

--- a/test/unit/test.config.object.type.js
+++ b/test/unit/test.config.object.type.js
@@ -18,9 +18,10 @@ describe('ngNotify type object configuration', function() {
 
     beforeEach(module('ngNotify'));
 
-    beforeEach(inject(function($injector, $document) {
+    beforeEach(inject(function($injector, $document, $timeout) {
 
         ngNotify = $injector.get('ngNotify');
+        $timeout.flush();
 
         doc = $document;
 

--- a/test/unit/test.config.string.type.js
+++ b/test/unit/test.config.string.type.js
@@ -18,9 +18,10 @@ describe('ngNotify type string configuration', function() {
 
     beforeEach(module('ngNotify'));
 
-    beforeEach(inject(function($injector, $document) {
+    beforeEach(inject(function($injector, $document, $timeout) {
 
         ngNotify = $injector.get('ngNotify');
+        $timeout.flush();
 
         doc = $document;
 

--- a/test/unit/test.dismiss.method.js
+++ b/test/unit/test.dismiss.method.js
@@ -18,9 +18,10 @@ describe('ngNotify dismiss method', function() {
 
     beforeEach(module('ngNotify'));
 
-    beforeEach(inject(function($injector, $document) {
+    beforeEach(inject(function($injector, $document, $timeout) {
 
         ngNotify = $injector.get('ngNotify');
+        $timeout.flush();
 
         doc = $document;
 


### PR DESCRIPTION
This pull request avoids issues with Angular compiling the `.ngn` element a second time when the document is parsed by waiting until the first digest cycle to insert the element into the document. When double-compiled, the ng-ifs do not function properly and the notify bar is displayed with no message. This issue is most likely encountered if the service is configured in a `run` block when the app is loading.

![screen shot 2015-11-10 at 10 20 04 am](https://cloud.githubusercontent.com/assets/507058/11066073/a294cece-8794-11e5-9b08-61ba517f5eee.png)

This affected us in Angular 1.3.x and 1.4.x but does not affect the demo since any configuration is performed in a controller. Unlike a `run` block, the controller will not be initialized until the document has been compiled. To test, add a `run` block to the demo to configure the service, like so:
```js
app.run(function(ngNotify) {
    ngNotify.config({
        theme: 'pastel',
        position: 'top',
        duration: 'f',
        type: 'success',
        sticky: true,
        html: true
    });
});
```

The run block is executed before Angular compiles the document, so the `.ngn` template is compiled, inserted, then compiled again as if it were in the original page markup. This `$timeout` delays until the first digest cycle to ensure that Angular has completely initialized before the element is added.