### PR TITLE
Fix warning message when ngSanitize is not found.

### DIFF
--- a/src/scripts/ng-notify.js
+++ b/src/scripts/ng-notify.js
@@ -231,7 +231,7 @@
                     if ((userOpts.html || defaultOptions.html) && !hasSanitize) {
 
                         $log.debug(
-                            "ngNotify warning: \ngSanitize couldn't be located.  In order to use the " +
+                            "ngNotify warning:\nngSanitize couldn't be located.  In order to use the " +
                             "'html' option, be sure the ngSanitize source is included in your project."
                         );
 


### PR DESCRIPTION
Noticed that there was a missing 'n' in the warning message that gets display when ngSanitize is not found.