### PR TITLE
ngNotifyProvider.options() created

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,22 @@ ngNotify.config({
 });
 ```
 
-Default configuration options can be set during the `run()` block.  If your app utilizes a global controller, the config options could be set there just as well.  For a discussion and working example on this topic, checkout [this comment](https://github.com/matowens/ng-notify/issues/16#issuecomment-104492193).
+Default configuration options can be set in the `config()` block by calling the `options()` method of the provider object
+```javascript
+angular
+    .module('myApp', ['ngNotify'])
+    .config(['ngNotifyProvider', function(ngNotifyProvider) {
+        ngNotifyProvider.options({
+            theme: 'pure',
+            position: 'bottom',
+            duration: 3000,
+            type: 'info',
+            sticky: false,
+            button: true,
+            html: false
+        });
+    }]);
+```
 
 ### Individual Configurations
 

--- a/src/scripts/ng-notify.js
+++ b/src/scripts/ng-notify.js
@@ -252,30 +252,35 @@
      */
     function NgNotifyService() {
 
+        // Defaults...
+
+        var DEFAULT_OPTIONS = {
+            theme: 'pure',
+            position: 'bottom',
+            duration: DEFAULT_DURATION,
+            type: 'info',
+            sticky: false,
+            button: true,
+            html: false,
+            target: SELECTOR
+        };
+
+        var DEFAULT_SCOPE = {
+            notifyClass: '',
+            notifyMessage: ''
+        };
+
+        this.options = function (params) {
+            params = params || {};
+            angular.extend(DEFAULT_OPTIONS, params);
+        };
+
         this.$get = ['$document', '$compile', '$log', '$rootScope', '$timeout', '$templateCache', 'NgNotifyFactory',
 
             function($document, $compile, $log, $rootScope, $timeout, $templateCache, NgNotifyFactory) {
 
                 var notification;
                 var notifyTimeout;
-
-                // Defaults...
-
-                var DEFAULT_OPTIONS = {
-                    theme: 'pure',
-                    position: 'bottom',
-                    duration: DEFAULT_DURATION,
-                    type: 'info',
-                    sticky: false,
-                    button: true,
-                    html: false,
-                    target: SELECTOR
-                };
-
-                var DEFAULT_SCOPE = {
-                    notifyClass: '',
-                    notifyMessage: ''
-                };
 
                 // Options...
 


### PR DESCRIPTION
this adds a new method `options()` which takes an options-object similar to the `config()` method. in fact it does the same. except it is callable from the provider object which gets injected in `angular.module().config()` and you can configure your notify-component at one central place

``` javascript
angular
    .module('myApp', ['ngNotify'])
    .config(['ngNotifyProvider', function(ngNotifyProvider) {
        ngNotifyProvider.options({
            theme: 'pure',
            position: 'bottom',
            duration: 3000,
            type: 'info',
            sticky: false,
            button: true,
            html: false
        });
    }]);
```
