### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ You can also install ng-notify with npm.
 
 As of v0.6.0, ng-notify is now available via the jsDelivr CDN if you'd prefer to go down that route.
 
-    //cdn.jsdelivr.net/angular.ng-notify/{version.number.here}/ng-notify.min.js
-    //cdn.jsdelivr.net/angular.ng-notify/{version.number.here}/ng-notify.min.css
+    //cdn.jsdelivr.net/npm/ng-notify@{version.number.here}/dist/ng-notify.min.js
+    //cdn.jsdelivr.net/npm/ng-notify@{version.number.here}/dist/ng-notify.min.css
 
 For example:
 
-    //cdn.jsdelivr.net/angular.ng-notify/0.6.0/ng-notify.min.js
-    //cdn.jsdelivr.net/angular.ng-notify/0.6.0/ng-notify.min.css
+    //cdn.jsdelivr.net/npm/ng-notify@0.7.1/dist/ng-notify.min.js
+    //cdn.jsdelivr.net/npm/ng-notify@0.7.1/dist/ng-notify.min.css
 
 And as always, you can download the source files straight from this repo - they're located in the `dist` dir.  Be sure to include the minified version of both js and css files.
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.8.0",
   "description": "A simple, lightweight module for displaying notifications in your AngularJS app.",
   "main": "./src/scripts/ng-notify.js",
+  "jsdelivr": "dist/ng-notify.min.js",
   "scripts": {
     "test": "grunt travis"
   },


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.
I also changed the default file to `dist/ng-notify.min.js`

You can find links for all files at https://www.jsdelivr.com/package/npm/ng-notify.

Feel free to ping me if you have any questions regarding this change.